### PR TITLE
Added mmapped writing and tests

### DIFF
--- a/Data/Vector/Storable/MMap.hs
+++ b/Data/Vector/Storable/MMap.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 module Data.Vector.Storable.MMap (
   System.IO.MMap.Mode(..),
   unsafeMMapMVector,
-  unsafeMMapVector
+  unsafeMMapVector,
+  writeMMapVector
 ) where
 
 import System.IO.MMap
@@ -10,8 +12,13 @@ import Foreign.Storable
 
 import qualified Data.Vector.Storable as I
 import qualified Data.Vector.Storable.Mutable as M
+
+import qualified Data.Vector.Generic as G
+
+
 import Data.Int
 
+import Control.Monad
 import Control.Monad.Primitive
 
 -- | Map a file into memory as a mutable vector.
@@ -36,3 +43,18 @@ unsafeMMapVector path range =
           Nothing -> Nothing
           Just (start, length) -> Just (start, length * sizeOf (undefined :: a))
      return $ I.unsafeFromForeignPtr foreignPtr offset (size `div` sizeOf (undefined :: a))
+
+
+-- | Write a file from a vector
+-- Be careful with existing files, parts behind the mapped range will stay
+-- as they are before the write operation.
+writeMMapVector :: forall v a. (Storable a, G.Vector v a) 
+                => FilePath -- ^ Path of the file to map
+                -> v a      -- ^ Vector to write
+                -> IO ()
+writeMMapVector path src = do
+    let len = G.length src
+    target <- unsafeMMapMVector path ReadWriteEx (Just (0,len))
+    I.copy target (G.convert src)
+
+{-# INLINABLE writeMMapVector #-}

--- a/test/TestSuite.hs
+++ b/test/TestSuite.hs
@@ -1,0 +1,27 @@
+
+
+
+
+module Main where
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+
+import qualified Data.Vector.Storable as V
+import qualified Data.Vector.Storable.MMap as V
+
+import           System.IO.Temp
+
+
+prop_read_write :: [Double] -> Property
+prop_read_write l = monadicIO $ do
+    let v = V.fromList l
+
+    v' <- run $ withSystemTempFile "vector-mmap-" $ \fn _ -> do
+      _ <- V.writeMMapVector fn v
+      V.unsafeMMapVector fn Nothing
+
+    assert (v == v')
+
+
+main = quickCheck prop_read_write

--- a/vector-mmap.cabal
+++ b/vector-mmap.cabal
@@ -11,7 +11,7 @@ Synopsis:       Memory map immutable and mutable vectors
 Description:
         Memory map immutable and mutable vectors.
 
-Cabal-Version:  >= 1.2
+Cabal-Version:  >= 1.8
 Build-Type:     Simple
 
 Library
@@ -19,3 +19,10 @@ Library
         Data.Vector.Storable.MMap
 
   Build-Depends: base >= 2 && < 5, mmap >= 0.5.4, vector >= 0.5, primitive >= 0.2.1
+
+
+Test-Suite quickcheck
+  Type: exitcode-stdio-1.0
+  HS-Source-Dirs: test
+  Main-is: TestSuite.hs
+  build-depends: base >= 2 && < 5, vector-mmap, vector, QuickCheck, temporary


### PR DESCRIPTION
Don't know if this will be useful to anyone except for me. But this PR adds a new function `writeMMapVector` which writes a generic vector to a mmapped file.

Also includes some tests to make sure that those files can be read back via mmapped reading.
